### PR TITLE
chore: failing test for "too few bytes to hash" error

### DIFF
--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -262,4 +262,12 @@ mod tests {
             ]
         )
     }
+    #[test]
+    #[should_panic(expected = "Algorithm is not defined for payloads smaller than 65 bytes")]
+    fn test_too_few() {
+        let mut hasher = PieceHasher::new();
+        let data = vec![0u8; 64];
+        hasher.update(&data);
+        hasher.finalize();
+    }
 }

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -21,4 +21,13 @@ export const testLib = {
       ])
     )
   },
+  'throws if payload as less than minimum allowed': async (assert) => {
+    const hasher = Hasher.create()
+    const bytes = new Uint8Array(64).fill(0)
+    hasher.write(bytes)
+    const error = assert.throws(
+      () => hasher.digestInto(new Uint8Array(36), 0, true)
+    )
+    assert.match(error.message, /not defined for payloads smaller than 65 bytes/)
+  },
 }


### PR DESCRIPTION
The expected error message is not returned. See https://github.com/web3-storage/fr32-sha2-256-trunc254-padded-binary-tree-multihash/issues/13

License: MIT