### PR TITLE
feat: enable console_error_panic_hook

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ impl PieceHasher {
 
 #[wasm_bindgen]
 pub fn create() -> PieceMultihasher {
+    util::set_panic_hook();
     PieceHasher::default()
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,3 +5,14 @@ const BYTES_PER_NODE: u64 = NODE_SIZE as u64;
 pub const fn from_height(height: u32) -> u64 {
     2u64.pow(height) * BYTES_PER_NODE
 }
+
+pub fn set_panic_hook() {
+    // When the `console_error_panic_hook` feature is enabled, we can call the
+    // `set_panic_hook` function at least once during initialization, and then
+    // we will get better error messages if our code ever panics.
+    //
+    // For more details see
+    // https://github.com/rustwasm/console_error_panic_hook#readme
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+}


### PR DESCRIPTION
> `console_error_panic_hook` lets you debug panics on wasm32-unknown-unknown by providing a panic hook that forwards panic messages to console.error.
https://github.com/rustwasm/console_error_panic_hook

With this enabled, the test from #15 still fails but with an informative console message before it

```
❯ pnpm test

> fr32-sha2-256-trunc254-padded-binary-tree-multihash@1.1.4 test /Users/oli/Code/web3-storage/fr32-sha2-256-trunc254-padded-binary-tree-multihash
> c8 --check-coverage --branches 0 --functions 0 --lines 0 entail test/**/*.spec.js

test/lib.spec.js
testLib ⦿ panicked at 'Algorithm is not defined for payloads smaller than 65 bytes', src/hasher.rs:114:13

Stack:

Error
    at imports.wbg.__wbg_new_abda76e883ba8a5f (file:///Users/oli/Code/web3-storage/fr32-sha2-256-trunc254-padded-binary-tree-multihash/gen/wasm.js:241:21)
    at data:application/wasm;base64,AGFzbQEAAAABaRBgAn9/AX9gAn9/AGADf39/AX9gA39/fwBgAX8AYAR/f39/AGAFf39/f38AYAABf2AFf39/f38Bf2ABfwF/YAAAYAR/f39/AX9gB39/f39/f38Bf2ACfn8Bf2AHf39/f39/fwBgAX8BfgLFAQYDd2JnHl9fd2JpbmRnZW5fY29weV90b190eXBlZF9hcnJheQADA3diZxpfX3diaW5kZ2VuX29iamVjdF9kcm9wX3JlZgAEA3diZxpfX3diZ19uZXdfYWJkYTc2ZTg4M2JhOGE1ZgAHA3diZxxfX3diZ19zdGFja182NTgyNzlmZTQ0NTQxY2Y2AAEDd2JnHF9fd2JnX2Vycm9yX2Y4NTE2NjdhZjcxYmNmYzYAAQN3YmcQX193YmluZGdlbl90aHJvdwABA39+AwACAQgDAggBAwwADQAAAAAGBQEFBQMDAAYBBQUBBQABDgEFBgEDBQMDAwMDAAgAAAABAAkBAQQEAQMEAQMEAgIBAQEADwgKAQELAAQHAQcEBgQBBAQBAAACAwAAAgAGAQALAQEBAAMEAAAAAAAEAAEKCgEAAwIHAQAJAAkEBAUBcAFAQAUDAQARBgkBfwFBgIDAAAsH0QELBm1lbW9yeQIAFl9fd2JnX3BpZWNlaGFzaGVyX2ZyZWUAPhJwaWVjZWhhc2hlcl9jcmVhdGUAVRFwaWV
```

However, as it says, it's only adds a `console.error` call before still throwing an unhelpful error shwon above. I'm posting this PR to demonstrate both how to enable this hook and it's limitations. The JS error should tell the calling code what happened.

I suspect the best course of action will be to have the rust impl return an Error result, and have the js wrapper throw the Error responses.

License: MIT