### PR TITLE
feat: expose cjs friendly module and function

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -89,5 +89,20 @@ export const concatDigest = async (left: AsyncIterable<Uint8Array>, right: Async
 }
 ```
 
+### Environments that do not support top level await
+
+The main module in this library uses a top-level await to load `wasm`. In environments that
+do not support top-level await (ie, legacy browser environments and many bundlers that build
+for them) you can use the `async` module like this:
+
+```javascript
+import { digest } from "fr32-sha2-256-trunc254-padded-binary-tree-multihash/async"
+
+export const createDigest = async (bytes: Uint8Array) => {
+  return await digest(bytes)
+}
+```
+
+
 
 [FIP0069]:https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0069.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "fr32-sha2-256-trunc254-padded-binary-tree-multihash",
       "version": "3.0.0",
+      "license": "Apache-2.0 OR MIT",
       "devDependencies": {
         "c8": "7.13.0",
         "chai": "4.3.7",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
       "types": "./dist/src/lib.js",
       "import": "./src/lib.js"
     },
+    "./async": {
+      "types": "./dist/src/async.js",
+      "import": "./src/async.js"
+    },
     "./sync": {
       "types": "./dist/src/sync.js",
       "import": "./src/sync.js"
@@ -55,14 +59,14 @@
     ]
   },
   "devDependencies": {
-    "entail": "^2.1.1",
     "c8": "7.13.0",
     "chai": "4.3.7",
+    "entail": "^2.1.1",
     "mocha": "10.2.0",
     "multiformats": "^11.0.2",
+    "nyc": "^15.1.0",
     "playwright-test": "^12.3.0",
-    "typescript": "^5.2.2",
-    "nyc": "^15.1.0"
+    "typescript": "^5.2.2"
   },
   "nyc": {
     "exclude": [

--- a/src/async.js
+++ b/src/async.js
@@ -1,0 +1,26 @@
+import load, { create } from "../gen/wasm.js"
+import { name, code, DIGEST_SIZE_LENGTH, CODE_LENGTH } from './constant.js'
+export * from "./type.js"
+export { name, code, DIGEST_SIZE_LENGTH, CODE_LENGTH }
+
+let ready = load()
+
+/**
+ * @param {Uint8Array} payload
+ * @returns {Promise<import("multiformats/link").MultihashDigest<typeof code>>}
+ */
+export const digest = async (payload) => {
+  await ready
+  const hasher = create()
+  hasher.write(payload)
+  const bytes = new Uint8Array(hasher.multihashByteLength())
+  hasher.digestInto(bytes, 0, true)
+  hasher.free()
+  return {
+    code,
+    // next byte will hold digest varint and it never exceeds the one byte
+    size: bytes[CODE_LENGTH],
+    digest: bytes.subarray(CODE_LENGTH + DIGEST_SIZE_LENGTH),
+    bytes
+  }
+}

--- a/src/constant.js
+++ b/src/constant.js
@@ -1,0 +1,54 @@
+import * as API from "./type.js"
+
+/**
+ * @see https://github.com/multiformats/multicodec/pull/331/files
+ */
+export const name = /** @type {const} */ (
+  "fr32-sha2-256-trunc254-padded-binary-tree"
+)
+
+/**
+ * @type {API.MulticodecCode<0x1011, typeof name>}
+ * @see https://github.com/multiformats/multicodec/pull/331/files
+ */
+export const code = 0x1011
+
+/**
+ * Multihash digest length in varint bytes
+ */
+export const DIGEST_SIZE_LENGTH = 1
+
+/**
+ * Multihash code size in varint bytes
+ */
+export const CODE_LENGTH = 2
+
+/**
+ * Max padding size in bytes
+ */
+export const MAX_PADDING_SIZE = 9
+
+/**
+ * One byte is used to store the tree height.
+ */
+export const HEIGHT_SIZE = 1
+
+/**
+ * Amount of bytes used to store the tree root.
+ */
+export const ROOT_SIZE = 32
+
+/**
+ * Size of the multihash digest in bytes.
+ */
+export const MAX_DIGEST_SIZE = MAX_PADDING_SIZE + HEIGHT_SIZE + ROOT_SIZE
+
+/**
+ * Multihash digest length in varint bytes
+ */
+export const MAX_DIGEST_LENGTH = 1
+
+/**
+ * Max number of bytes required to fit this multihash
+ */
+export const MAX_SIZE = CODE_LENGTH + MAX_DIGEST_LENGTH + MAX_DIGEST_SIZE

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,55 +1,8 @@
 import load, { create } from "../gen/wasm.js"
-import * as API from "./type.js"
+import { code, CODE_LENGTH, HEIGHT_SIZE, ROOT_SIZE, MAX_SIZE } from './constant.js'
 export * from "./type.js"
+export { code, CODE_LENGTH, HEIGHT_SIZE, ROOT_SIZE, MAX_SIZE }
 
 await load()
-
-/**
- * @see https://github.com/multiformats/multicodec/pull/331/files
- */
-export const name = /** @type {const} */ (
-  "fr32-sha2-256-trunc254-padded-binary-tree"
-)
-
-/**
- * @type {API.MulticodecCode<0x1011, typeof name>}
- * @see https://github.com/multiformats/multicodec/pull/331/files
- */
-export const code = 0x1011
-
-/**
- * Multihash code size in varint bytes
- */
-export const CODE_LENGTH = 2
-
-/**
- * Max padding size in bytes
- */
-const MAX_PADDING_SIZE = 9
-
-/**
- * One byte is used to store the tree height.
- */
-export const HEIGHT_SIZE = 1
-
-/**
- * Amount of bytes used to store the tree root.
- */
-export const ROOT_SIZE = 32
-
-/**
- * Size of the multihash digest in bytes.
- */
-const MAX_DIGEST_SIZE = MAX_PADDING_SIZE + HEIGHT_SIZE + ROOT_SIZE
-
-/**
- * Multihash digest length in varint bytes
- */
-const MAX_DIGEST_LENGTH = 1
-
-/**
- * Max number of bytes required to fit this multihash
- */
-export const MAX_SIZE = CODE_LENGTH + MAX_DIGEST_LENGTH + MAX_DIGEST_SIZE
 
 export { create }

--- a/test/lib.spec.js
+++ b/test/lib.spec.js
@@ -1,6 +1,7 @@
 import * as Hasher from "../src/lib.js"
+import * as Async from '../src/async.js'
 import * as Link from "multiformats/link"
-import { digest, varint } from "multiformats"
+import { varint } from "multiformats"
 import * as Digest from "multiformats/hashes/digest"
 import * as Raw from "multiformats/codecs/raw"
 
@@ -473,4 +474,20 @@ export const testLib = {
       "bafkzcibd64bqlxticxolgseegik2stpfgkkuwyf6kufex3doorkvmzpjuxwe4dz4"
     )
   },
+
+  async: async assert => {
+    // compute digest using default module
+    const hasher = Hasher.create()
+    const bytes = new Uint8Array(65).fill(0)
+    hasher.write(bytes)
+
+    const digest = new Uint8Array(hasher.multihashByteLength())
+    hasher.digestInto(digest, 0, true)
+
+    // compute digest using async module
+    const asyncDigest = await Async.digest(bytes)
+
+    // they should be the same
+    assert.deepEqual(asyncDigest.bytes, digest)
+  }
 }


### PR DESCRIPTION
per https://github.com/web3-storage/fr32-sha2-256-trunc254-padded-binary-tree-multihash/issues/24 introduce an entrypoint that does not use a top-level await, as many target environments still do not support them