### PR TITLE
fix: dynamic import if no url can be created

### DIFF
--- a/gen/wasm.js
+++ b/gen/wasm.js
@@ -256,13 +256,7 @@ async function __wbg_init(input) {
     if (wasm !== undefined) return wasm;
 
     if (typeof input === 'undefined') {
-        try {
-            input = new URL('wasm_bg.wasm', import.meta.url);
-        } catch {
-            // try with dynamic import - CF workers runtime does not have import.meta.url
-            const module = await import('./wasm_bg.wasm')
-            input = module.default
-        }
+        input = new URL('wasm_bg.wasm', import.meta.url);
     }
     const imports = __wbg_get_imports();
 

--- a/gen/wasm.js
+++ b/gen/wasm.js
@@ -256,7 +256,13 @@ async function __wbg_init(input) {
     if (wasm !== undefined) return wasm;
 
     if (typeof input === 'undefined') {
-        input = new URL('wasm_bg.wasm', import.meta.url);
+        try {
+            input = new URL('wasm_bg.wasm', import.meta.url);
+        } catch {
+            // try with dynamic import - CF workers runtime does not have import.meta.url
+            const module = await import('./wasm_bg.wasm')
+            input = module.default
+        }
     }
     const imports = __wbg_get_imports();
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -6,10 +6,11 @@ export { code, CODE_LENGTH, HEIGHT_SIZE, ROOT_SIZE, MAX_SIZE }
 // load bytecode in Cloudflare Workers as wasm import
 // all other paths are disallowed by embedder
 let bytecode
+// https://developers.cloudflare.com/workers/runtime-apis/web-standards/#navigatoruseragent
+export const CLOUDFLARE_WORKERS_NAVIGATOR = "Cloudflare-Workers"
 /* c8 ignore start */
 try {
-  // @ts-expect-error only in Cloudflare
-  if (HTMLRewriter) {
+  if (globalThis.navigator?.userAgent === CLOUDFLARE_WORKERS_NAVIGATOR) {
     // @ts-expect-error no declaration types
     bytecode = (await import('../gen/wasm_bg.wasm')).default
   }

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,8 +1,11 @@
+// @ts-expect-error no type declarations
+import bytecode from '../gen/wasm_bg.wasm'
+
 import load, { create } from "../gen/wasm.js"
 import { code, CODE_LENGTH, HEIGHT_SIZE, ROOT_SIZE, MAX_SIZE } from './constant.js'
 export * from "./type.js"
 export { code, CODE_LENGTH, HEIGHT_SIZE, ROOT_SIZE, MAX_SIZE }
 
-await load()
+await load(bytecode)
 
 export { create }

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,5 +1,11 @@
 import load, { create } from "../gen/wasm.js"
-import { code, CODE_LENGTH, HEIGHT_SIZE, ROOT_SIZE, MAX_SIZE } from './constant.js'
+import {
+  code,
+  CODE_LENGTH,
+  HEIGHT_SIZE,
+  ROOT_SIZE,
+  MAX_SIZE,
+} from "./constant.js"
 export * from "./type.js"
 export { code, CODE_LENGTH, HEIGHT_SIZE, ROOT_SIZE, MAX_SIZE }
 
@@ -11,8 +17,10 @@ export const CLOUDFLARE_WORKERS_NAVIGATOR = "Cloudflare-Workers"
 /* c8 ignore start */
 try {
   if (globalThis.navigator?.userAgent === CLOUDFLARE_WORKERS_NAVIGATOR) {
-    // @ts-expect-error no declaration types
-    bytecode = (await import('../gen/wasm_bg.wasm')).default
+    // playwright tries to bundle imported file when it sees import with
+    // string literal. We workaround by using variable to import.
+    const wasm = "../gen/wasm_bg.wasm"
+    bytecode = (await import(wasm)).default
   }
 } catch {}
 /* c8 ignore stop */

--- a/src/lib.js
+++ b/src/lib.js
@@ -3,12 +3,16 @@ import { code, CODE_LENGTH, HEIGHT_SIZE, ROOT_SIZE, MAX_SIZE } from './constant.
 export * from "./type.js"
 export { code, CODE_LENGTH, HEIGHT_SIZE, ROOT_SIZE, MAX_SIZE }
 
+// load bytecode in Cloudflare Workers as wasm import
+// all other paths are disallowed by embedder
 let bytecode
-
 /* c8 ignore start */
 try {
-  // @ts-expect-error no declaration types
-  bytecode = (await import('../gen/wasm_bg.wasm')).default
+  // @ts-expect-error only in Cloudflare
+  if (HTMLRewriter) {
+    // @ts-expect-error no declaration types
+    bytecode = (await import('../gen/wasm_bg.wasm')).default
+  }
 } catch {}
 /* c8 ignore stop */
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,10 +1,16 @@
-// @ts-expect-error no type declarations
-import bytecode from '../gen/wasm_bg.wasm'
-
 import load, { create } from "../gen/wasm.js"
 import { code, CODE_LENGTH, HEIGHT_SIZE, ROOT_SIZE, MAX_SIZE } from './constant.js'
 export * from "./type.js"
 export { code, CODE_LENGTH, HEIGHT_SIZE, ROOT_SIZE, MAX_SIZE }
+
+let bytecode
+
+/* c8 ignore start */
+try {
+  // @ts-expect-error no declaration types
+  bytecode = (await import('../gen/wasm_bg.wasm')).default
+} catch {}
+/* c8 ignore stop */
 
 await load(bytecode)
 


### PR DESCRIPTION
Per https://github.com/web3-storage/w3up/issues/1273 there are issues running this code in CF workers environment. Async option also does not work given it also relies on the URL (and also of course atm only supports full in memory).

This PR addresses this by fallbacking to a dynamic import if it fails to create URL. I tested this in https://github.com/web3-storage/piece-compute-worker/pull/5 successfully (of course if tried out now, needs to install node modules and manually do this change here). However, I think this code is generated and would love to have this somehow supported upstream. But I have no idea on how code was generated?

Could we get this fix in now and see if we can get it somehow fixed upstream?