### PR TITLE
fix: not used exports and types versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,6 @@
       "types": "./dist/src/async.js",
       "import": "./src/async.js"
     },
-    "./sync": {
-      "types": "./dist/src/sync.js",
-      "import": "./src/sync.js"
-    },
     "./wasm-import": {
       "types": "./dist/src/wasm-import.js",
       "import": "./src/wasm-import.js"
@@ -53,8 +49,11 @@
       ".": [
         "dist/src/lib.d.ts"
       ],
-      "sync": [
-        "dist/src/sync.d.ts"
+      "async": [
+        "dist/src/async.d.ts"
+      ],
+      "wasm-import": [
+        "dist/src/wasm-import.d.ts"
       ]
     }
   },


### PR DESCRIPTION
per https://github.com/web3-storage/fr32-sha2-256-trunc254-padded-binary-tree-multihash/pull/33#discussion_r1471927887