### PR TITLE
feat: export async wasm import

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
       "types": "./dist/src/async.js",
       "import": "./src/async.js"
     },
+    "./async-wasm-import": {
+      "types": "./dist/src/async-wasm-import.js",
+      "import": "./src/async-wasm-import.js"
+    },
     "./wasm-import": {
       "types": "./dist/src/wasm-import.js",
       "import": "./src/wasm-import.js"
@@ -51,6 +55,9 @@
       ],
       "async": [
         "dist/src/async.d.ts"
+      ],
+      "async-wasm-import": [
+        "dist/src/async-wasm-import.d.ts"
       ],
       "wasm-import": [
         "dist/src/wasm-import.d.ts"

--- a/src/async-wasm-import.js
+++ b/src/async-wasm-import.js
@@ -1,0 +1,32 @@
+import load, { create } from "../gen/wasm.js"
+import { name, code, DIGEST_SIZE_LENGTH, CODE_LENGTH } from './constant.js'
+export * from "./type.js"
+export { name, code, DIGEST_SIZE_LENGTH, CODE_LENGTH }
+
+// load bytecode with import
+// there are runtimes like cloudflare workers where
+// all other paths are disallowed by embedder
+// @ts-expect-error
+import bytecode from "../gen/wasm_bg.wasm"
+
+let ready = load(bytecode)
+
+/**
+ * @param {Uint8Array} payload
+ * @returns {Promise<import("multiformats/link").MultihashDigest<typeof code>>}
+ */
+export const digest = async (payload) => {
+  await ready
+  const hasher = create()
+  hasher.write(payload)
+  const bytes = new Uint8Array(hasher.multihashByteLength())
+  hasher.digestInto(bytes, 0, true)
+  hasher.free()
+  return {
+    code,
+    // next byte will hold digest varint and it never exceeds the one byte
+    size: bytes[CODE_LENGTH],
+    digest: bytes.subarray(CODE_LENGTH + DIGEST_SIZE_LENGTH),
+    bytes
+  }
+}


### PR DESCRIPTION
Looks like `w3up-client` actually uses the `async`  export to expose [CJS friendly mode](https://github.com/web3-storage/fr32-sha2-256-trunc254-padded-binary-tree-multihash/pull/25). So, to be able to run this in Cloudflare, we actually need the combo of both. Still for users of `fr32-sha2-256-trunc254-padded-binary-tree-multihash` directly in CF such as https://github.com/web3-storage/piece-compute-worker/pull/5 we can pull directly the non async version